### PR TITLE
upgrade gatsby to latest v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "eslint-config-prettier": "^6.15.0",
         "eslint-plugin-jsdoc": "^30.7.13",
         "eslint-plugin-react": "^7.23.2",
-        "gatsby": "^4.9.1",
+        "gatsby": "^4.25.9",
         "husky": "^1.3.1",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^26.6.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mattdalzell.com",
-  "description": "Personal Site",
-  "version": "1.2.0",
+  "description": "Matt Dalzell's Personal Site",
+  "version": "1.2.1",
   "author": "Matt Dalzell",
   "dependencies": {
     "@types/react-helmet": "^5.0.8",
@@ -44,7 +44,7 @@
     "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-jsdoc": "^30.7.13",
     "eslint-plugin-react": "^7.23.2",
-    "gatsby": "^4.9.1",
+    "gatsby": "^4.25.9",
     "husky": "^1.3.1",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^26.6.3",


### PR DESCRIPTION
Upgrades to the latest v4 of gatsby. This _should_ enable upgrading to React v18